### PR TITLE
Link from page 2

### DIFF
--- a/app/views/govuk2/making-child-maintenance-arrangement/arrange-child-maintenance-yourself.html
+++ b/app/views/govuk2/making-child-maintenance-arrangement/arrange-child-maintenance-yourself.html
@@ -76,6 +76,8 @@ GOV.UK Prototype Kit
                 </li>
               </ul>
 
+              <p class="govuk-body">If a private arrangement would not work you can <a class="govuk-link" href="https://www.gov.uk/manage-child-maintenance-case">use the Child Maintenance Service.</a></p>
+
               <h2 class="govuk-heading-m">Working out payments</h2>
               <p class="govuk-body">If you agree to make regular payments, you can <a class="govuk-link" href="https://www.gov.uk/calculate-child-maintenance">use the child maintenance calculator</a> to help agree an amount.</p>
               <p class="govuk-body">It shows you how much would be paid if you used the Child Maintenance Service, but if you're making a private arrangements you can negotiate something different.</a></p>
@@ -114,7 +116,7 @@ GOV.UK Prototype Kit
 
 
               <h2 class="govuk-heading-m">If a private arrangement does not work</h2>
-              <p class="govuk-body">If a private arrangement does not work you can <a class="govuk-link" href="https://www.gov.uk/manage-child-maintenance-case">use the Child Maintenance Service</a></p>
+              <p class="govuk-body">If a private arrangement does not work you can <a class="govuk-link" href="https://www.gov.uk/manage-child-maintenance-case">use the Child Maintenance Service.</a></p>
 
 
 


### PR DESCRIPTION
Addition to the page 2 introduction to add an early link to use CMS for parents who identify an FBA is not approriate.