### PR TITLE
Disabled links

### DIFF
--- a/app/views/prototype3iteration1/web-arrange-child-maintenance-yourself.html
+++ b/app/views/prototype3iteration1/web-arrange-child-maintenance-yourself.html
@@ -9,13 +9,13 @@ GOV.UK Prototype Kit
 <div class="govuk-breadcrumbs ">
   <ol class="govuk-breadcrumbs__list">
     <li class="govuk-breadcrumbs__list-item">
-      <a class="govuk-breadcrumbs__link" href="https://www.gov.uk">Home</a>
+      <a class="govuk-breadcrumbs__link" href="https://www.gov.uk" onclick="return false;>Home</a>
     </li>
     <li class="govuk-breadcrumbs__list-item">
-      <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/browse/births-deaths-marriages">Births, deaths, marriages and care</a>
+      <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/browse/births-deaths-marriages" onclick="return false;">Births, deaths, marriages and care</a>
     </li>
     <li class="govuk-breadcrumbs__list-item">
-      <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/browse/births-deaths-marriages/child-adoption">Having a child, parenting and adoption</a>
+      <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/browse/births-deaths-marriages/child-adoption" onclick="return false;">Having a child, parenting and adoption</a>
     </li>
   </ol>
 </div>
@@ -79,39 +79,42 @@ GOV.UK Prototype Kit
               <p class="govuk-body">If making your own arrangement would not work you can <a class="govuk-link" href="web-using-child-maintenance-service">use the Child Maintenance Service.</a></p>
 
               <h2 class="govuk-heading-m">Working out payments</h2>
-              <p class="govuk-body">If you agree to make regular payments, you can <a class="govuk-link" href="https://www.gov.uk/calculate-child-maintenance">use the child maintenance calculator</a> to help agree an amount.</p>
+              <p class="govuk-body">If you agree to make regular payments, you can <a class="govuk-link" href="https://www.gov.uk/calculate-child-maintenance" onclick="return false;">use the child maintenance calculator</a> to help agree an amount.</p>
               <p class="govuk-body">It shows you how much would be paid if you used the Child Maintenance Service, but if you're making your own arrangement you can negotiate something different.</a></p>
 
               <h2 class="govuk-heading-m">Get help to make an arrangement<h2>
               <p class="govuk-body">You can read guidance on:</p>
               <ul class="govuk-list govuk-list--bullet">
                 <li>
-                  <a class="govuk-link" href="https://www.gov.uk/government/publications/working-out-the-cost-of-raising-your-children">working out the cost of raising your children</a>
+                  <a class="govuk-link" href="https://www.gov.uk/government/publications/working-out-the-cost-of-raising-your-children" onclick="return false;">working out the cost of raising your children</a>
                 </li>
                 <li>
-                  <a class="govuk-link" href="https://www.gov.uk/government/publications/planning-your-child-maintenance-conversation">having a conversation about child maintenance</a>
+                  <a class="govuk-link" href="https://www.gov.uk/government/publications/planning-your-child-maintenance-conversation" onclick="return false;">having a conversation about child maintenance</a>
                 </li>
                 <li>
-                  <a class="govuk-link" href="https://www.gov.uk/government/publications/your-child-maintenance-arrangement">recording your agreement</a>
+                  <a class="govuk-link" href="https://www.gov.uk/government/publications/your-child-maintenance-arrangement" onclick="return false;">recording your agreement</a>
                 </li>
               </ul>
               <p class="govuk-body">You can contact Child Maintenance Options for support.</p>
               <div class="govuk-inset-text">
+                <strong>Online service</strong><br>
+                <a class="govuk-link" href="welcome">Use the child maintenance online service</a> to see what your options are and get support.<br>
+                <br>
                 <strong>Child Maintenance Options</strong><br>
                 Telephone: 0800 953 0191<br>
-                <a href="https://www.timeforstorm.com/IM/endpoint/guest/5465/CMO%20Webchat/7281ae0010fa609cec9d53f872458b01ecddd9ce016f3c464a3c8d2a97f58026">Webchat</a><br>
-                <a href="https://www2.dwp.gov.uk/contact-cmoptions/en/new-contact.asp">Online form</a><br>
+                <a href="https://www.timeforstorm.com/IM/endpoint/guest/5465/CMO%20Webchat/7281ae0010fa609cec9d53f872458b01ecddd9ce016f3c464a3c8d2a97f58026" onclick="return false;">Webchat</a><br>
+                <a href="https://www2.dwp.gov.uk/contact-cmoptions/en/new-contact.asp" onclick="return false;">Online form</a><br>
                 Monday to Friday, 8am to 8pm<br>
                 <br>
-                <a href="https://dwpcmgoptions.signvideo.net">Video relay service</a> for British Sign Language (BSL) users - <a href="https://www.youtube.com/watch?v=Osx7FFxFpNY">check you can use the service</a><br>
+                <a href="https://dwpcmgoptions.signvideo.net" onclick="return false;">Video relay service</a> for British Sign Language (BSL) users - <a href="https://www.youtube.com/watch?v=Osx7FFxFpNY" onclick="return false;">check you can use the service</a><br>
                 Monday to Friday, 8am to 5pm<br>
                 <br>
                 Welsh language: 0800 408 0308<br>
                 Monday to Friday, 8am to 5pm<br>
-                <a href="https://www.gov.uk/call-charges">Find out about call charges</a>
+                <a href="https://www.gov.uk/call-charges" onclick="return false;">Find out about call charges</a>
               </div>
               <div class="govuk-inset-text">
-                There are different contact details if you live in <a href="https://www.nidirect.gov.uk/contacts/contacts-az/child-maintenance-choices">Northern Ireland</a>.
+                There are different contact details if you live in <a href="https://www.nidirect.gov.uk/contacts/contacts-az/child-maintenance-choices" onclick="return false;">Northern Ireland</a>.
               </div>
 
 
@@ -139,13 +142,13 @@ GOV.UK Prototype Kit
               <h2 class="govuk-heading-s">Explore the topic</h2>
               <ul class="govuk-list">
                 <li>
-                  <a class="govuk-link" href="https://www.gov.uk/browse/births-deaths-marriages/child-adoption">Having a child, parenting and adoption</a>
+                  <a class="govuk-link" href="https://www.gov.uk/browse/births-deaths-marriages/child-adoption" onclick="return false;">Having a child, parenting and adoption</a>
                 </li>
                 <li>
-                  <a class="govuk-link" href="https://www.gov.uk/browse/births-deaths-marriages/marriage-divorce">Marriage, civil partnership and divorce</a>
+                  <a class="govuk-link" href="https://www.gov.uk/browse/births-deaths-marriages/marriage-divorce" onclick="return false;">Marriage, civil partnership and divorce</a>
                 </li>
                 <li>
-                  <a class="govuk-link" href="https://www.gov.uk/browse/childcare-parenting/divorce-separation-legal">Divorce, separation and legal issues</a>
+                  <a class="govuk-link" href="https://www.gov.uk/browse/childcare-parenting/divorce-separation-legal" onclick="return false;">Divorce, separation and legal issues</a>
                 </li>
               </ul>
 
@@ -153,16 +156,6 @@ GOV.UK Prototype Kit
     </div>
 
     <div class="govuk-grid-column-one-third">
-      <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-        <div class="govuk-notification-banner__header">
-        </div>
-        <div class="govuk-notification-banner__content">
-          <h2 class="govuk-heading-m" id="subsection-title">
-            Brexit
-          </h2>
-            <a class="govuk-link" href="https://www.gov.uk/transition">Check how the new Brexit rules affect you</a>
-        </div>
-      </div>
       <aside class="app-related-items" role="complementary">
         <h2 class="govuk-heading-m" id="subsection-title">
           Related content
@@ -175,12 +168,12 @@ GOV.UK Prototype Kit
                 </a>
               </li>
               <li>
-                <a class="govuk-link" href="https://www.gov.uk/manage-child-maintenance-case">
+                <a class="govuk-link" href="https://www.gov.uk/manage-child-maintenance-case" onclick="return false;">
                   Manage your Child Maintenance Service case
                 </a>
               </li>
               <li>
-                <a class="govuk-link" href="https://www.gov.uk/calculate-child-maintenance">
+                <a class="govuk-link" href="https://www.gov.uk/calculate-child-maintenance" onclick="return false;">
                   Calculate your child maintenance
                 </a>
               </li>

--- a/app/views/prototype3iteration1/web-overview.html
+++ b/app/views/prototype3iteration1/web-overview.html
@@ -9,13 +9,13 @@ GOV.UK Prototype Kit
 <div class="govuk-breadcrumbs ">
   <ol class="govuk-breadcrumbs__list">
     <li class="govuk-breadcrumbs__list-item">
-      <a class="govuk-breadcrumbs__link" href="https://www.gov.uk">Home</a>
+      <a class="govuk-breadcrumbs__link" href="https://www.gov.uk" onclick="return false;">Home</a>
     </li>
     <li class="govuk-breadcrumbs__list-item">
-      <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/browse/births-deaths-marriages">Births, deaths, marriages and care</a>
+      <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/browse/births-deaths-marriages" onclick="return false;">Births, deaths, marriages and care</a>
     </li>
     <li class="govuk-breadcrumbs__list-item">
-      <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/browse/births-deaths-marriages/child-adoption">Having a child, parenting and adoption</a>
+      <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/browse/births-deaths-marriages/child-adoption" onclick="return false;">Having a child, parenting and adoption</a>
     </li>
   </ol>
 </div>
@@ -46,7 +46,7 @@ GOV.UK Prototype Kit
               <h2 class="govuk-heading-m">Overview</h2>
               <p class="govuk-body">Child maintenance is an arrangement between you and the other parent of your child. It covers how your child’s living costs will be paid for when one parent does not live with them.</p>
               <div class="govuk-inset-text">
-                <a class="govuk-link" href="https://www.gov.uk/gwneud-trefniant-cynhaliaeth-plant">This guide is also available in Welsh (Cymraeg).</a>
+                <a class="govuk-link" href="https://www.gov.uk/gwneud-trefniant-cynhaliaeth-plant" onclick="return false;">This guide is also available in Welsh (Cymraeg).</a>
               </div>
               <p class="govuk-body">Both parents are responsible for the costs of raising their child, even if they do not see them.</p>
               <p class="govuk-body">Child maintenance can be either:</p>
@@ -81,12 +81,12 @@ GOV.UK Prototype Kit
                 online or digital abuse
                 </li>
               </ul>
-              <p class="govuk-body">You can <a class="govuk-link" href="web-using-child-maintenance-service">use the Child Maintenance Service</a> to arrange child maintenance if you do not want to contact the other parent yourself. They will contact the other parent for you.</p>
-              <p class="govuk-body">You can <a class="govuk-link" href="https://www.gov.uk/guidance/domestic-abuse-how-to-get-help">get help and support if you've experienced domestic abuse.</a>
+              <p class="govuk-body">You can <a class="govuk-link" href="web-using-child-maintenance-service"">use the Child Maintenance Service</a> to arrange child maintenance if you do not want to contact the other parent yourself. They will contact the other parent for you.</p>
+              <p class="govuk-body">You can <a class="govuk-link" href="https://www.gov.uk/guidance/domestic-abuse-how-to-get-help" onclick="return false;">get help and support if you've experienced domestic abuse.</a>
 
               <h2 class="govuk-heading-m">How it affects benefits</h2>
               <p class="govuk-body">Child maintenance payments will not affect any benefits that you and your children get. You will not have to pay tax on them.</p>
-              <p class="govuk-body">Your Council Tax Reduction could be affected. <a class="govuk-link" href="https://www.gov.uk/find-local-council">Contact your local council</a> to find out if this applies to you.</p>
+              <p class="govuk-body">Your Council Tax Reduction could be affected. <a class="govuk-link" href="https://www.gov.uk/find-local-council" onclick="return false;">Contact your local council</a> to find out if this applies to you.</p>
 
               <br>
               <br>
@@ -101,13 +101,13 @@ GOV.UK Prototype Kit
               <h2 class="govuk-heading-s">Explore the topic</h2>
               <ul class="govuk-list">
                 <li>
-                  <a class="govuk-link" href="https://www.gov.uk/browse/births-deaths-marriages/child-adoption">Having a child, parenting and adoption</a>
+                  <a class="govuk-link" href="https://www.gov.uk/browse/births-deaths-marriages/child-adoption" onclick="return false;">Having a child, parenting and adoption</a>
                 </li>
                 <li>
-                  <a class="govuk-link" href="https://www.gov.uk/browse/births-deaths-marriages/marriage-divorce">Marriage, civil partnership and divorce</a>
+                  <a class="govuk-link" href="https://www.gov.uk/browse/births-deaths-marriages/marriage-divorce" onclick="return false;">Marriage, civil partnership and divorce</a>
                 </li>
                 <li>
-                  <a class="govuk-link" href="https://www.gov.uk/browse/childcare-parenting/divorce-separation-legal">Divorce, separation and legal issues</a>
+                  <a class="govuk-link" href="https://www.gov.uk/browse/childcare-parenting/divorce-separation-legal" onclick="return false;">Divorce, separation and legal issues</a>
                 </li>
               </ul>
 
@@ -116,18 +116,6 @@ GOV.UK Prototype Kit
     </div>
 
     <div class="govuk-grid-column-one-third">
-      <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-        <div class="govuk-notification-banner__header">
-        </div>
-        <div class="govuk-notification-banner__content">
-          <h2 class="govuk-heading-m" id="subsection-title">
-            Brexit
-          </h2>
-            <a class="govuk-link" href="https://www.gov.uk/transition">Check how the new Brexit rules affect you</a>
-        </div>
-      </div>
-
-
 
       <aside class="app-related-items" role="complementary">
         <h2 class="govuk-heading-m" id="subsection-title">
@@ -141,12 +129,12 @@ GOV.UK Prototype Kit
                 </a>
               </li>
               <li>
-                <a class="govuk-link" href="https://www.gov.uk/manage-child-maintenance-case">
+                <a class="govuk-link" href="https://www.gov.uk/manage-child-maintenance-case" onclick="return false;">
                   Manage your Child Maintenance Service case
                 </a>
               </li>
               <li>
-                <a class="govuk-link" href="https://www.gov.uk/calculate-child-maintenance">
+                <a class="govuk-link" href="https://www.gov.uk/calculate-child-maintenance" onclick="return false;">
                   Calculate your child maintenance
                 </a>
               </li>

--- a/app/views/prototype3iteration1/web-using-child-maintenance-service.html
+++ b/app/views/prototype3iteration1/web-using-child-maintenance-service.html
@@ -9,13 +9,13 @@ GOV.UK Prototype Kit
 <div class="govuk-breadcrumbs ">
   <ol class="govuk-breadcrumbs__list">
     <li class="govuk-breadcrumbs__list-item">
-      <a class="govuk-breadcrumbs__link" href="https://www.gov.uk">Home</a>
+      <a class="govuk-breadcrumbs__link" href="https://www.gov.uk" onclick="return false;">Home</a>
     </li>
     <li class="govuk-breadcrumbs__list-item">
-      <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/browse/births-deaths-marriages">Births, deaths, marriages and care</a>
+      <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/browse/births-deaths-marriages" onclick="return false;">Births, deaths, marriages and care</a>
     </li>
     <li class="govuk-breadcrumbs__list-item">
-      <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/browse/births-deaths-marriages/child-adoption">Having a child, parenting and adoption</a>
+      <a class="govuk-breadcrumbs__link" href="https://www.gov.uk/browse/births-deaths-marriages/child-adoption" onclick="return false;">Having a child, parenting and adoption</a>
     </li>
   </ol>
 </div>
@@ -53,12 +53,12 @@ GOV.UK Prototype Kit
               <p class="govuk-body">You can use the Child Maintenance Service to arrange child maintenance for you. This is less flexible than <a class="govuk-link" href="web-arrange-child-maintenance-yourself">making your own arrangement</a> because they will decide how much maintenance will be paid.</p>
               <p class="govuk-body">Using the Child Maintenance Service might be a good option for if you don't feel safe dealing with the other parent, or you don't think they will pay.</p>
               <div class="govuk-inset-text">
-                <p class="govuk-body">You can <a class="govuk-link" href="welcome">use the child maintenance online service</a> to see what your options are and to apply to the Child Maintenance Service.</p>
+                <p class="govuk-body"><a class="govuk-link" href="welcome">Use the child maintenance online service</a> to see what your options are and to apply to the Child Maintenance Service.</p>
               </div>
               <p class="govuk-body">The Child Maintenance Service will:</p>
               <ul class="govuk-list govuk-list--bullet">
                 <li>
-                  work out child maintenance payment amounts (you can <a class="govuk-link" href="https://www.gov.uk/calculate-child-maintenance">do this yourself with the calculator</a>)
+                  work out child maintenance payment amounts (you can <a class="govuk-link" href="https://www.gov.uk/calculate-child-maintenance" onclick="return false;">do this yourself with the calculator</a>)
                 </li>
                 <li>
                   arrange for the other parent to pay
@@ -73,7 +73,7 @@ GOV.UK Prototype Kit
                   look at the payments if changes in parents’ circumstances are reported
                 </li>
                 <li>
-                  help <a class="govuk-link" href="https://www.gov.uk/manage-child-maintenance-case/disagreements-about-parentage">if someone denies they’re the parent of a child</a>
+                  help <a class="govuk-link" href="https://www.gov.uk/manage-child-maintenance-case/disagreements-about-parentage" onclick="return false;">if someone denies they’re the parent of a child</a>
                 </li>
               </ul>
 
@@ -86,7 +86,7 @@ GOV.UK Prototype Kit
               <p class="govuk-body">You can also set up a pre-payment card which is not connected to a bank account. The paying parent can set up a standing order to your pre-payment card.</p>
 
               <h2 class="govuk-heading-m">Eligibility</h2>
-              <p class="govuk-body">Your child needs to be under 16, or under 20 if they stay in <a class="govuk-link" href="https://www.gov.uk/child-benefit-16-19">approved education or training</a>.</p>
+              <p class="govuk-body">Your child needs to be under 16, or under 20 if they stay in <a class="govuk-link" href="https://www.gov.uk/child-benefit-16-19" onclick="return false;">approved education or training</a>.</p>
               <p class="govuk-body">You need to live in the UK as your main home and have the right to live here.</p>
               <p class="govuk-body">You can apply if you’re:</p>
               <ul class="govuk-list govuk-list--bullet">
@@ -107,7 +107,7 @@ GOV.UK Prototype Kit
 
               <h3 class="govuk-heading-s">If one of the parents lives outside the UK<h3>
               <p class="govuk-body">You cannot apply if the child and the parent with main day-to-day care live outside the UK.</p>
-              <p class="govuk-body">The service can only help <a class="govuk-link" href="https://www.gov.uk/child-maintenance-if-one-parent-lives-abroad/other-parent-works-for-british-organisation">if the paying parent works outside the UK for a British organisation</a>.</p>
+              <p class="govuk-body">The service can only help <a class="govuk-link" href="https://www.gov.uk/child-maintenance-if-one-parent-lives-abroad/other-parent-works-for-british-organisation" onclick="return false;">if the paying parent works outside the UK for a British organisation</a>.</p>
               <h2 class="govuk-heading-m">Fees<h2>
               <p class="govuk-body">The application fee is £20.</p>
               <p class="govuk-body">You will not have to pay this if you:</p>
@@ -156,19 +156,19 @@ GOV.UK Prototype Kit
                 <br>
                 <strong>Contact Child Maintenance Options</strong><br>
                 Telephone: 0800 953 0191<br>
-                <a href="https://www.timeforstorm.com/IM/endpoint/guest/5465/CMO%20Webchat/7281ae0010fa609cec9d53f872458b01ecddd9ce016f3c464a3c8d2a97f58026">Webchat</a><br>
-                <a href="https://www2.dwp.gov.uk/contact-cmoptions/en/new-contact.asp">Online form</a><br>
+                <a href="https://www.timeforstorm.com/IM/endpoint/guest/5465/CMO%20Webchat/7281ae0010fa609cec9d53f872458b01ecddd9ce016f3c464a3c8d2a97f58026" onclick="return false;">Webchat</a><br>
+                <a href="https://www2.dwp.gov.uk/contact-cmoptions/en/new-contact.asp" onclick="return false;">Online form</a><br>
                 Monday to Friday, 8am to 8pm<br>
                 <br>
-                <a href="https://dwpcmgoptions.signvideo.net">Video relay service</a> for British Sign Language (BSL) users - <a href="https://www.youtube.com/watch?v=Osx7FFxFpNY">check you can use the service</a><br>
+                <a href="https://dwpcmgoptions.signvideo.net" onclick="return false;">Video relay service</a> for British Sign Language (BSL) users - <a href="https://www.youtube.com/watch?v=Osx7FFxFpNY" onclick="return false;">check you can use the service</a><br>
                 Monday to Friday, 8am to 5pm<br>
                 <br>
                 Welsh language: 0800 408 0308<br>
                 Monday to Friday, 8am to 5pm<br>
-                <a href="https://www.gov.uk/call-charges">Find out about call charges</a>
+                <a href="https://www.gov.uk/call-charges" onclick="return false;">Find out about call charges</a>
               </div>
               <div class="govuk-inset-text">
-                There are different contact details if you live in <a href="https://www.nidirect.gov.uk/contacts/contacts-az/child-maintenance-choices">Northern Ireland</a>.
+                There are different contact details if you live in <a href="https://www.nidirect.gov.uk/contacts/contacts-az/child-maintenance-choices" onclick="return false;">Northern Ireland</a>.
               </div>
 
               <h3 class="govuk-heading-s">How your information is used<h2>
@@ -205,13 +205,13 @@ GOV.UK Prototype Kit
               <h2 class="govuk-heading-s">Explore the topic</h2>
               <ul class="govuk-list">
                 <li>
-                  <a class="govuk-link" href="https://www.gov.uk/browse/births-deaths-marriages/child-adoption">Having a child, parenting and adoption</a>
+                  <a class="govuk-link" href="https://www.gov.uk/browse/births-deaths-marriages/child-adoption" onclick="return false;">Having a child, parenting and adoption</a>
                 </li>
                 <li>
-                  <a class="govuk-link" href="https://www.gov.uk/browse/births-deaths-marriages/marriage-divorce">Marriage, civil partnership and divorce</a>
+                  <a class="govuk-link" href="https://www.gov.uk/browse/births-deaths-marriages/marriage-divorce" onclick="return false;">Marriage, civil partnership and divorce</a>
                 </li>
                 <li>
-                  <a class="govuk-link" href="https://www.gov.uk/browse/childcare-parenting/divorce-separation-legal">Divorce, separation and legal issues</a>
+                  <a class="govuk-link" href="https://www.gov.uk/browse/childcare-parenting/divorce-separation-legal" onclick="return false;">Divorce, separation and legal issues</a>
                 </li>
               </ul>
 
@@ -219,16 +219,6 @@ GOV.UK Prototype Kit
     </div>
 
     <div class="govuk-grid-column-one-third">
-      <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-        <div class="govuk-notification-banner__header">
-        </div>
-        <div class="govuk-notification-banner__content">
-          <h2 class="govuk-heading-m" id="subsection-title">
-            Brexit
-          </h2>
-            <a class="govuk-link" href="https://www.gov.uk/transition">Check how the new Brexit rules affect you</a>
-        </div>
-      </div>
       <aside class="app-related-items" role="complementary">
         <h2 class="govuk-heading-m" id="subsection-title">
           Related content
@@ -241,12 +231,12 @@ GOV.UK Prototype Kit
                 </a>
               </li>
               <li>
-                <a class="govuk-link" href="https://www.gov.uk/manage-child-maintenance-case">
+                <a class="govuk-link" href="https://www.gov.uk/manage-child-maintenance-case" onclick="return false;">
                   Manage your Child Maintenance Service case
                 </a>
               </li>
               <li>
-                <a class="govuk-link" href="https://www.gov.uk/calculate-child-maintenance">
+                <a class="govuk-link" href="https://www.gov.uk/calculate-child-maintenance" onclick="return false;">
                   Calculate your child maintenance
                 </a>
               </li>


### PR DESCRIPTION
Disabled all links from the mock GOV.UK pages to actual GOV.UK content to keep users in the prototype at this point.

Removed the Brexit box entirely.