### PR TITLE
More personalisation improvements

### DIFF
--- a/app/views/prototype4/iteration1/includes/own-arrangement-generic.html
+++ b/app/views/prototype4/iteration1/includes/own-arrangement-generic.html
@@ -1,0 +1,12 @@
+<li>
+  decide how much one parent will pay
+</li>
+<li>
+  change the amount when needed
+</li>
+<li>
+  decide how often payments will be made
+</li>
+<li>
+  agree for a parent to pay for specific things, like school uniforms or trips
+</li>

--- a/app/views/prototype4/iteration1/includes/own-arrangement-paying.html
+++ b/app/views/prototype4/iteration1/includes/own-arrangement-paying.html
@@ -1,0 +1,12 @@
+<li>
+  decide how much you will pay
+</li>
+<li>
+  change the amount when needed
+</li>
+<li>
+  decide how often you will make payments
+</li>
+<li>
+  agree for you to pay for specific things, like school uniforms or trips
+</li>

--- a/app/views/prototype4/iteration1/includes/own-arrangement-receiving.html
+++ b/app/views/prototype4/iteration1/includes/own-arrangement-receiving.html
@@ -1,0 +1,12 @@
+<li>
+  decide how much you will be paid
+</li>
+<li>
+  change the amount when needed
+</li>
+<li>
+  decide how often you will be paid
+</li>
+<li>
+  agree for the other parent to pay for specific things, like school uniforms or trips
+</li>

--- a/app/views/prototype4/iteration1/includes/types-of-payment-generic.html
+++ b/app/views/prototype4/iteration1/includes/types-of-payment-generic.html
@@ -1,0 +1,9 @@
+<h1 class="govuk-heading-l">Paying and receiving child maintenance</h1>
+<p class="govuk-body">If you choose to use the Child Maintenance Service there are 2 ways payments can be made.</p>
+<h2 class="govuk-heading-s">Direct Pay</h2>
+<p class="govuk-body">The paying parent will pay maintenance directly to the receiving parent’s bank account.</p>
+<p class="govuk-body">You do not need to have any contact with the other parent and there are no additional fees.</p>
+
+<h2 class="govuk-heading-s">Collect and Pay</h2>
+<p class="govuk-body">The Child Maintenance Service will collect maintenance from the paying parent and pass it to the receiving parent.</p>
+<p class="govuk-body">There are additional fees for you and the other parent and you can only use Collect and Pay if the paying parent agrees to it or does not respond to an application.</p>

--- a/app/views/prototype4/iteration1/includes/types-of-payment-paying.html
+++ b/app/views/prototype4/iteration1/includes/types-of-payment-paying.html
@@ -1,0 +1,9 @@
+<h1 class="govuk-heading-l">Paying child maintenance</h1>
+<p class="govuk-body"">If you choose to use the Child Maintenance Service there are 2 ways you can make payments</p>
+<h2 class="govuk-heading-s">Direct Pay</h2>
+<p class="govuk-body">You pay maintenance directly into the other parent’s bank account.</p>
+<p class="govuk-body">You do not need to have any contact with the other parent and there are no additional fees.</p>
+
+<h2 class="govuk-heading-s">Collect and Pay</h2>
+<p class="govuk-body">The Child Maintenance Service will collect maintenance from you and pass it to the other parent.</p>
+<p class="govuk-body">There are additional fees for you and the other parent.</p>

--- a/app/views/prototype4/iteration1/includes/types-of-payment-receiving.html
+++ b/app/views/prototype4/iteration1/includes/types-of-payment-receiving.html
@@ -1,0 +1,9 @@
+<h1 class="govuk-heading-l">Receiving child maintenance</h1>
+<p class="govuk-body">If you choose to use the Child Maintenance Service there are 2 ways you can get payments</p>
+<h2 class="govuk-heading-s">Direct Pay</h2>
+<p class="govuk-body">The other parent will pay maintenance directly to your bank account.</p>
+<p class="govuk-body">You do not need to have any contact with the other parent and there are no additional fees.</p>
+
+<h2 class="govuk-heading-s">Collect and Pay</h2>
+<p class="govuk-body">The Child Maintenance Service will collect maintenance from the other parent and pass it to you.</p>
+<p class="govuk-body">There are additional fees for you and the other parent and you can only use Collect and Pay if the other parent agrees to it or does not respond to the application.</p>

--- a/app/views/prototype4/iteration1/make-your-own-arrangement.html
+++ b/app/views/prototype4/iteration1/make-your-own-arrangement.html
@@ -25,34 +25,15 @@
             <p class="govuk-body">You can make your own maintenance arrangements between parents. No one else has to be involved and it can be whatever you agree. For example, you and the other parent can:</p>
             <ul class="govuk-list govuk-list--bullet">
 
+              <!--Paying parent-->
               {% if data['will-you-be-paying-or-receiving'] === 'paying' %}
-              <li>
-                decide how much you will pay
-              </li>
-              <li>
-                change the amount when needed
-              </li>
-              <li>
-                decide how often you will make payments
-              </li>
-              <li>
-                agree for you to pay for specific things, like school uniforms or trips
-              </li>
-              {% endif %}
-
-              {% if data['will-you-be-paying-or-receiving'] === 'receiving' %}
-              <li>
-                decide how much you will be paid
-              </li>
-              <li>
-                change the amount when needed
-              </li>
-              <li>
-                decide how often you will be paid
-              </li>
-              <li>
-                agree for the other parent to pay for specific things, like school uniforms or trips
-              </li>
+                {% include './includes/own-arrangement-paying.html' %}
+              <!--Receiving parent-->
+              {% elseif data['will-you-be-paying-or-receiving'] === 'receiving' %}
+                {% include './includes/own-arrangement-receiving.html' %}
+              <!--Generic - this should never be seen but exists to gracefully handle potential errors-->
+              {% else %}
+                {% include './includes/own-arrangement-generic.html' %}
               {% endif %}
 
             </ul>

--- a/app/views/prototype4/iteration1/types-of-payment.html
+++ b/app/views/prototype4/iteration1/types-of-payment.html
@@ -20,36 +20,17 @@
         <form method="post" novalidate>
           <div class="govuk-form-group">
 
-
-
-
+            <!--Paying parent-->
             {% if data['will-you-be-paying-or-receiving'] === 'paying' %}
-
-            <h1 class="govuk-heading-l">Paying child maintenance</h1>
-            <p class="govuk-body"">If you choose to use the Child Maintenance Service there are 2 ways you can make payments</p>
-            <h2 class="govuk-heading-s">Direct Pay</h2>
-            <p class="govuk-body">You pay maintenance directly into the other parent’s bank account.</p>
-            <p class="govuk-body">You do not need to have any contact with the other parent and there are no additional fees.</p>
-
-            <h2 class="govuk-heading-s">Collect and Pay</h2>
-            <p class="govuk-body">The Child Maintenance Service will collect maintenance from you and pass it to the other parent.</p>
-            <p class="govuk-body">There are additional fees for you and the other parent.</p>
+              {% include './includes/types-of-payment-paying.html' %}
+            <!--Receiving parent-->
+            {% elseif data['will-you-be-paying-or-receiving'] === 'receiving' %}
+              {% include './includes/types-of-payment-receiving.html' %}
+            <!--Generic - this should never be seen but exists to gracefully handle potential errors-->
+            {% else %}
+              {% include './includes/types-of-payment-generic.html' %}
             {% endif %}
 
-
-            {% if data['will-you-be-paying-or-receiving'] === 'receiving' %}
-
-            <h1 class="govuk-heading-l">Receiving child maintenance</h1>
-            <p class="govuk-body">If you choose to use the Child Maintenance Service there are 2 ways you can get payments</p>
-            <h2 class="govuk-heading-s">Direct Pay</h2>
-            <p class="govuk-body">The other parent will pay maintenance directly to your bank account.</p>
-            <p class="govuk-body">You do not need to have any contact with the other parent and there are no additional fees.</p>
-
-            <h2 class="govuk-heading-s">Collect and Pay</h2>
-            <p class="govuk-body">The Child Maintenance Service will collect maintenance from the other parent and pass it to you.</p>
-            <p class="govuk-body">There are additional fees for you and the other parent and you can only use Collect and Pay if the other parent agrees to it or does not respond to the application.</p>
-
-            {% endif %}
           </div>
 
           <a href="what-do-you-want-to-do" role="button" draggable="false" class="govuk-button" data-module="govuk-button">

--- a/app/views/prototype4/iteration1/use-the-child-maintenance-service.html
+++ b/app/views/prototype4/iteration1/use-the-child-maintenance-service.html
@@ -24,10 +24,13 @@
 
             <h1 class="govuk-heading-l">Your options: Use the Child Maintenance Service</h1>
 
+            <!--Paying parent-->
             {% if data['will-you-be-paying-or-receiving'] === 'paying' %}
               {% include './includes/use-cms-paying.html' %}
+            <!--Receiving parent-->
             {% elseif data['will-you-be-paying-or-receiving'] === 'receiving' %}
               {% include './includes/use-cms-receiving.html' %}
+            <!--Generic - this should never be seen but exists to gracefully handle potential errors-->
             {% else %}
               {% include './includes/use-cms-generic.html' %}
             {% endif %}


### PR DESCRIPTION
Moved personalised content for 'own arrangment' and 'types of payment' into external include files to be referenced by pages.

Added 'generic' content for both pages too, in order to gracefully handle error scenarios (eg where session date cannot be recovered).